### PR TITLE
Add async client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "zellular"
 version = "0.2.4"
 description = "SDK package for zellular sequencer"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.7.2"
 authors = [
     { name = "Mahdi", email = "mahdi@zellular.xyz" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ authors = [
 license = { text = "MIT" }
 dependencies = [
     "eigensdk",
-    "requests",
     "xxhash",
-    "packaging"
+    "packaging",
+    "httpx>=0.24.1",
 ]
 
 keywords = ["sdk", "sequencer", "blockchain"]  # optional

--- a/tests/test_zellular_static.py
+++ b/tests/test_zellular_static.py
@@ -2,7 +2,7 @@ from typing import Any
 import logging
 
 import pytest
-from zellular.zellular import Zellular
+from zellular.zellular import Zellular, ZellularAsync
 from zellular.networks.static import StaticNetwork
 
 logger = logging.getLogger(__name__)
@@ -14,7 +14,20 @@ def verifier(load_test_nodes: dict[str, dict[str, Any]]) -> Zellular:
     return Zellular(app="simple_app", network=network)
 
 
+@pytest.fixture
+def verifier_async(load_test_nodes: dict[str, dict[str, Any]]) -> ZellularAsync:
+    network = StaticNetwork(load_test_nodes, threshold_percent=30)
+    return ZellularAsync(app="simple_app", network=network)
+
+
 def test_blocking_send(verifier: Zellular, generate_test_tx: str) -> None:
     index = verifier.send(generate_test_tx, blocking=True)
+    logger.info(f"The sent batch sequenced at {index}")
+    assert index is not None and index > 0
+
+
+@pytest.mark.asyncio
+async def test_blocking_send_async(verifier_async: ZellularAsync, generate_test_tx: str) -> None:
+    index = await verifier_async.send(generate_test_tx, blocking=True)
     logger.info(f"The sent batch sequenced at {index}")
     assert index is not None and index > 0

--- a/zellular/zellular.py
+++ b/zellular/zellular.py
@@ -1,11 +1,11 @@
+import httpx
 import logging
 import json
 import random
 import asyncio
-import requests
-from typing import Generator, Any
+from contextlib import aclosing
+from typing import Any, AsyncGenerator, Generator
 import xxhash
-import aiohttp
 from packaging.version import parse as parse_version
 
 from zellular.networks.base import Network
@@ -15,9 +15,9 @@ hash = xxhash.xxh128_hexdigest
 logger = logging.getLogger(__name__)
 
 
-class Zellular:
+class ZellularAsync:
     """
-    Zellular client for interacting with a distributed app's sequencer network.
+    Zellular async client for interacting with a distributed app's sequencer network.
 
     This class provides methods to:
     - Fetch finalized batches for a given app
@@ -38,27 +38,34 @@ class Zellular:
         gateway: str | None = None,
         timeout: float = 5.0,
     ):
+        self.client = httpx.AsyncClient()
         self.app = app
         self.network = network
         self.timeout = timeout
-        self.gateway = gateway or self._get_random_active_operator(app).socket
+        self.gateway = gateway
 
-    def batches(self, after: int = 0) -> Generator[tuple[str, int], None, None]:
+    async def get_gateway(self):
+        if not self.gateway:
+            self.gateway = (await self._get_random_active_operator(self.app)).socket
+
+        return self.gateway
+
+    async def batches(self, after: int = 0) -> AsyncGenerator[tuple[str, int], None]:
         if after < 0:
             raise ValueError("Parameter 'after' should be equal to or greater than 0")
         chaining_hash: str | None = "" if after == 0 else None
 
         while True:
-            chaining_hash, batch_list = self._get_finalized_batches(
+            chaining_hash, batch_list = await self._get_finalized_batches(
                 after, chaining_hash
             )
             for batch in batch_list:
                 after += 1
                 yield batch, after
 
-    def get_last_finalized(self) -> dict[str, Any] | None:
-        url = f"{self.gateway}/node/{self.app}/batches/finalized/last"
-        response = requests.get(url, timeout=self.timeout)
+    async def get_last_finalized(self) -> dict[str, Any] | None:
+        url = f"{await self.get_gateway()}/node/{self.app}/batches/finalized/last"
+        response = await self.client.get(url, timeout=self.timeout)
         response.raise_for_status()
 
         result = response.json()
@@ -83,15 +90,15 @@ class Zellular:
             raise ValueError(f"Finalized batch verification failed: {data}")
         return data
 
-    def send(self, batch: str, blocking: bool = False) -> int | None:
+    async def send(self, batch: str, blocking: bool = False) -> int | None:
         if blocking:
-            last_finalized = self.get_last_finalized()
+            last_finalized = await self.get_last_finalized()
             index = last_finalized["index"] if last_finalized else 0
 
-        url = f"{self.gateway}/node/{self.app}/batches"
-        response = requests.put(
+        url = f"{await self.get_gateway()}/node/{self.app}/batches"
+        response = await self.client.put(
             url,
-            data=batch,
+            content=batch,
             headers={"Content-Type": "text/plain"},
             timeout=self.timeout,
         )
@@ -100,9 +107,10 @@ class Zellular:
         if not blocking:
             return None
 
-        for received_batch, idx in self.batches(after=index):
-            if batch == received_batch:
-                return idx
+        async with aclosing(self.batches(after=index)) as gen:
+            async for received_batch, idx in gen:
+                if batch == received_batch:
+                    return idx
 
         # This can never happen as batches method wait for new batches forever
         return None
@@ -136,8 +144,8 @@ class Zellular:
             op for op, _, locked, _ in version_matched if locked >= highest_finalized
         ]
 
-    def _get_random_active_operator(self, app: str) -> Operator:
-        operators = asyncio.run(self.get_active_operators(app))
+    async def _get_random_active_operator(self, app: str) -> Operator:
+        operators = await self.get_active_operators(app)
         if not operators:
             raise RuntimeError("No active operators found")
         return random.choice(operators)
@@ -163,15 +171,15 @@ class Zellular:
         logger.info(f"app: {self.app}, index: {index}, verification result: {result}")
         return result
 
-    def _get_finalized_batches(
+    async def _get_finalized_batches(
         self, after: int, chaining_hash: str | None
     ) -> tuple[str, list[str]]:
         res = []
         index = after if chaining_hash is not None else after - 1
 
         while True:
-            response = requests.get(
-                f"{self.gateway}/node/{self.app}/batches/finalized?after={index}",
+            response = await self.client.get(
+                f"{await self.get_gateway()}/node/{self.app}/batches/finalized?after={index}",
                 timeout=self.timeout,
             )
             response.raise_for_status()
@@ -209,30 +217,81 @@ class Zellular:
     ) -> tuple[Operator, int, int, str] | None:
         url = f"{operator.socket}/node/state"
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url, timeout=self.timeout) as resp:
-                    if resp.status != 200:
-                        return None
-                    data = await resp.json()
-                    node_data = data.get("data", {})
+            resp = await self.client.get(url, timeout=self.timeout)
+            if resp.status_code != 200:
+                return None
+            data = resp.json()
+            node_data = data.get("data", {})
 
-                    # Skip sequencer nodes as they can't be directly connected to by clients
-                    if node_data.get("sequencer") is True:
-                        logger.info(f"Skipping sequencer node: {operator.id}")
-                        return None
+            # Skip sequencer nodes as they can't be directly connected to by clients
+            if node_data.get("sequencer") is True:
+                logger.info(f"Skipping sequencer node: {operator.id}")
+                return None
 
-                    app_data = node_data.get("apps", {}).get(app)
-                    version = node_data.get("version")
-                    if not app_data or not version:
-                        return None
-                    return (
-                        operator,
-                        app_data["last_finalized_index"],
-                        app_data["last_locked_index"],
-                        version,
-                    )
+            app_data = node_data.get("apps", {}).get(app)
+            version = node_data.get("version")
+            if not app_data or not version:
+                return None
+            return (
+                operator,
+                app_data["last_finalized_index"],
+                app_data["last_locked_index"],
+                version,
+            )
         except Exception as e:
             logger.warning(
                 f"Failed to load state of {operator.id} from {operator.socket}: {e}"
             )
             return None
+
+
+class Zellular:
+    """
+    Zellular client for interacting with a distributed app's sequencer network.
+
+    This class provides methods to:
+    - Fetch finalized batches for a given app
+    - Submit new batches and optionally wait for finalization
+    - Dynamically discover a healthy gateway node from active operators
+
+    It operates over a pluggable network backend, enabling the same logic to work
+    with different network topologies and consensus mechanisms.
+
+    If no gateway is provided at initialization, a random active operator running the
+    latest software version and up-to-date consensus state will be selected.
+    """
+
+    def __init__(
+        self,
+        app: str,
+        network: Network,
+        gateway: str | None = None,
+        timeout: float = 5.0,
+    ):
+        self._zellular = ZellularAsync(app, network, gateway, timeout)
+        self._loop = asyncio.new_event_loop()
+
+    def batches(self, after: int = 0) -> Generator[tuple[str, int], None, None]:
+        # an async generator is pretty tricky to wrap in a sync
+        # function, so we'll just duplicate this bit of code here.
+
+        if after < 0:
+            raise ValueError("Parameter 'after' should be equal to or greater than 0")
+        chaining_hash: str | None = "" if after == 0 else None
+
+        while True:
+            chaining_hash, batch_list = self._loop.run_until_complete(
+                self._zellular._get_finalized_batches(after, chaining_hash))
+            for batch in batch_list:
+                after += 1
+                yield batch, after
+
+    def get_last_finalized(self) -> dict[str, Any] | None:
+        return self._loop.run_until_complete(self._zellular.get_last_finalized())
+
+    def send(self, batch: str, blocking: bool = False) -> int | None:
+        return self._loop.run_until_complete(self._zellular.send(batch, blocking))
+
+    # this is supposed to be async in both versions
+    async def get_active_operators(self, app: str) -> list[Operator]:
+        return await self._zellular.get_active_operators(app)


### PR DESCRIPTION
ZellularAsync is the new async client. The original client is refactored to use the new one under the hood.

There are a couple of notes to pay attention to:
 - The minimum python version was changed to 3.7.2, since with the original (3.6) the dependencies were not resolving.
 - There is a very small change in the way the `gateway` member variable behaves. If it's set to None, `Zellular.gateway` would stay None until one of the async methods is called, causing `_get_random_active_operator` to be called.
 - The `Zellular` class now uses an event loop to run the async methods in `ZellularAsync`. While I believe the performance impact should be minimal, there's no test to prove this.
 - The tests only cover the `send` method so we don't have any proof that the other methods behave as before.

NOTE: The safer method of doing this was leaving the `Zellular` class as-is, and writing a new `ZellularAsync` class with mostly duplicated code. This is a little ugly and has as slightly higher cost of maintenance, but would make sure there is no performance hit, and no change in behavior at all. We could still go this route if we deem it worthwhile.